### PR TITLE
OS aware running.vim

### DIFF
--- a/ftplugin/chuck/running.vim
+++ b/ftplugin/chuck/running.vim
@@ -3,7 +3,11 @@ if !exists("g:chuck_command")
 endif
 
 function! ChuckRunBuffer()
-    silent !clear
+    if has("win32") || has("win16")
+        silent !cls
+    else
+        silent !clear
+    endif
     execute "!" . g:chuck_command . " " . bufname("%")
 endfunction
 


### PR DESCRIPTION
Added a conditional statement to check OS and run the appropriate console-clearing statement; Windows uses "cls" rather than "clear." This way Windows users will have console clearing rather than error messages.